### PR TITLE
Fix build issue with includes 

### DIFF
--- a/tenderloin/bcattach/hciattach_st.c
+++ b/tenderloin/bcattach/hciattach_st.c
@@ -35,7 +35,7 @@
 #include <dirent.h>
 #include <sys/param.h>
 
-#include <bluetooth/bluetooth.h>
+#include "bluetooth.h"
 
 #include "hciattach.h"
 

--- a/tenderloin/bcattach/hciattach_ti.c
+++ b/tenderloin/bcattach/hciattach_ti.c
@@ -37,9 +37,9 @@
 #include <sys/param.h>
 #include <sys/ioctl.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/hci_lib.h>
+#include <bluetooth.h>
+#include <hci.h>
+#include <hci_lib.h>
 
 #include "hciattach.h"
 

--- a/tenderloin/bcattach/hciattach_ti.c
+++ b/tenderloin/bcattach/hciattach_ti.c
@@ -37,9 +37,9 @@
 #include <sys/param.h>
 #include <sys/ioctl.h>
 
-#include <bluetooth.h>
-#include <hci.h>
-#include <hci_lib.h>
+#include "bluetooth.h"
+#include "hci.h"
+#include "hci_lib.h"
 
 #include "hciattach.h"
 

--- a/tenderloin/bcattach/hciattach_tialt.c
+++ b/tenderloin/bcattach/hciattach_tialt.c
@@ -40,9 +40,9 @@
 #include <sys/param.h>
 #include <sys/ioctl.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/hci_lib.h>
+#include "bluetooth.h"
+#include "hci.h"
+#include "hci_lib.h"
 
 #include "hciattach.h"
 


### PR DESCRIPTION
Due to the order in which things are build, clean build for TP sometimes
fails (due to BlueZ4 not being build yet?). Since we have the headers
available in the current dir as well, use those instead.

Due to the order in which things are build, clean build for TP sometimes
fails (due to BlueZ4 not being build yet?). Since we have the headers
available in the current dir as well, use those instead.

Signed-off-by: Herman van Hazendonk github.com@herrie.org
